### PR TITLE
Fixed Swift Compiler Warning

### DIFF
--- a/Source/MJSnackBar.swift
+++ b/Source/MJSnackBar.swift
@@ -136,7 +136,7 @@ open class MJSnackBar: UIView {
     @objc fileprivate func snackBarTouched() {
         
         if let data = self.currentlyDisplayedData {
-            if data.action != nil && data.action!.characters.count > 0 {
+            if data.action != nil && data.action!.count > 0 {
                 self.hide(afterDelay: false, reason: .user) { }
                 self.delegate?.snackBarActionTriggered(with: data)
             }


### PR DESCRIPTION
With Swift 4 many changes have been added to Strings, one of them is calling its 'characters' property is deprecated.

More info: https://useyourloaf.com/blog/updating-strings-for-swift-4/